### PR TITLE
fix: create redis client in `load` of adapter

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Test
 
 on:
   push:
-    branches: '*'
+    branches: '**'
     tags-ignore: '*'
 
 jobs:

--- a/mod_test.js
+++ b/mod_test.js
@@ -1,5 +1,5 @@
 import { z } from "./deps.js";
-import { assert } from "./dev_deps.js";
+import { assert, resolves } from "./dev_deps.js";
 
 import RedisCacheAdapter from "./mod.js";
 
@@ -18,6 +18,26 @@ const schema = z.object({
     ),
 });
 
+const baseStubClient = {
+  get: resolves(),
+  set: resolves(),
+  del: resolves(),
+  keys: resolves(),
+  scan: resolves(),
+};
+
 Deno.test("validate schema", () => {
   assert(schema.safeParse(RedisCacheAdapter()).success);
+});
+
+Deno.test("returns a redis client", async () => {
+  const res = await RedisCacheAdapter({}, {
+    client: { connect: resolves(baseStubClient) },
+  }).load();
+  assert(res.client);
+});
+
+Deno.test("returns an adapter", () => {
+  const res = RedisCacheAdapter().link({ client: baseStubClient })();
+  assert(res.createStore);
 });


### PR DESCRIPTION
`connect` on the deno redis client returns a `Promise`, so we need to resolve this Promise in the `load` function, prior to `link` being called.