### PR TITLE
feat(cluster): use separate cluster connect in cluster mode #12

### DIFF
--- a/deps.js
+++ b/deps.js
@@ -2,3 +2,4 @@ export * as R from "https://cdn.skypack.dev/ramda@^0.27.1";
 export { default as crocks } from "https://cdn.skypack.dev/crocks@^0.12.4";
 export * as z from "https://cdn.skypack.dev/zod@^3";
 export * as redis from "https://deno.land/x/redis@v0.25.0/mod.ts";
+export * as redisCluster from "https://deno.land/x/redis@v0.25.0/experimental/cluster/mod.ts";

--- a/mod.js
+++ b/mod.js
@@ -1,4 +1,4 @@
-import { R, redis } from "./deps.js";
+import { R, redis, redisCluster } from "./deps.js";
 
 import createAdapter from "./adapter.js";
 
@@ -9,22 +9,38 @@ const { mergeRight } = R;
  * @property {string} hostname
  * @property {number?} port - defaults to 6379
  *
+ * @typedef RedisAdapterOptions
+ * @property {{ connect: () => Promise<{}> }?} client
+ * @property {boolean?} cluster - defaults to false
+ *
  * @param {RedisClientArgs} config
+ * @param {RedisAdapterOptions?} options
  * @returns {object}
  */
 export default function RedisCacheAdapter(
   config = {},
-  options = { client: redis, cluster: false },
+  options = {},
 ) {
-  options.client = options.client || redis;
+  options.client = options.client || (options.cluster ? redisCluster : redis);
 
   async function load(prevLoad = {}) {
     // prefer args passed to adapter over previous load
     config = mergeRight(prevLoad, config);
-    const client = await options.client.connect(config);
+
+    let client;
     if (options.cluster) {
-      await client.clusterMeet(config.hostname, config.port);
-      await client.clusterNodes();
+      // redis cluster client
+      client = await options.client.connect({
+        nodes: [
+          {
+            hostname: config.hostname,
+            port: config.port,
+          },
+        ],
+      });
+    } else {
+      // regular redis client
+      client = await options.client.connect(config);
     }
     // create client
     return { client };

--- a/mod_test.js
+++ b/mod_test.js
@@ -1,5 +1,5 @@
 import { z } from "./deps.js";
-import { assert, resolves } from "./dev_deps.js";
+import { assert, assertEquals, resolves } from "./dev_deps.js";
 
 import RedisCacheAdapter from "./mod.js";
 
@@ -32,9 +32,24 @@ Deno.test("validate schema", () => {
 
 Deno.test("returns a redis client", async () => {
   const res = await RedisCacheAdapter({}, {
-    client: { connect: resolves(baseStubClient) },
+    client: { connect: resolves({ foo: "bar" }) },
   }).load();
+
   assert(res.client);
+  assertEquals(res.client.foo, "bar");
+});
+
+Deno.test("returns a redis cluster client", async () => {
+  const res = await RedisCacheAdapter({ hostname: "foo", port: 6380 }, {
+    client: {
+      connect: (config) => Promise.resolve(config),
+    },
+    cluster: true,
+  }).load();
+
+  assert(res.client);
+  assertEquals(res.client.nodes[0].hostname, "foo");
+  assertEquals(res.client.nodes[0].port, 6380);
 });
 
 Deno.test("returns an adapter", () => {


### PR DESCRIPTION
closes #12

also adds a test to ensure we pass the correct shape to the redis cluster `connect`